### PR TITLE
Add docker/setup-qemu-action step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,25 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # pin@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # pin@v3
         with:
           registry: quay.io
           username: ${{ vars.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # pin@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # pin@v3
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # pin@v6
         with:


### PR DESCRIPTION
From the [docs](https://goreleaser.com/cookbooks/multi-platform-docker-images/)

For buildx to work properly, you'll need to install qemu. On GitHub actions, the easiest way is to use docker/setup-qemu-action.  It's also important that the FROM in your Dockerfile is multi-platform, otherwise it'll not work.  As long as you have Qemu and Docker set up, everything should just work.