### PR TITLE
Add leaktk scan --gitleaks-config to provide a custom gitleaks config

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -226,7 +226,7 @@ func scanCommand() *cobra.Command {
 	flags.StringP("kind", "k", "GitRepo", "the kind of resource to scan")
 	flags.StringP("options", "o", "{}", "additional request options formatted as JSON")
 	flags.Int("leak-exit-code", 0, "the exit code when leaks are found (default 0)")
-	flags.StringP("gitleaks-config", "g", "", "the path to a custom gitleaks config")
+	flags.StringP("gitleaks-config", "", "", "the path to a custom gitleaks config")
 
 	return scanCommand
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -85,6 +85,17 @@ func runScan(cmd *cobra.Command, args []string) {
 		logger.Fatal("invalid leak-exit-code: %v", err)
 	}
 
+	gitleaksConfig, err := cmd.Flags().GetString("gitleaks-config")
+	if err != nil {
+		logger.Fatal("invalid gitleaks-config: error=%q", err.Error())
+	}
+
+	// Providing a gitleaks-config via command line arguments takes
+	// precedence over gitleaks config set in the leaktk config file
+	if len(gitleaksConfig) != 0 {
+		cfg.Scanner.Patterns.Gitleaks.ConfigPath = gitleaksConfig
+	}
+
 	request, err := scanCommandToRequest(cmd, args)
 	if err != nil {
 		logger.Fatal("could not generate scan request: %v", err)
@@ -205,6 +216,7 @@ func scanCommand() *cobra.Command {
 	flags.StringP("kind", "k", "GitRepo", "the kind of resource to scan")
 	flags.StringP("options", "o", "{}", "additional request options formatted as JSON")
 	flags.Int("leak-exit-code", 0, "the exit code when leaks are found (default 0)")
+	flags.StringP("gitleaks-config", "g", "", "the path to a custom gitleaks config")
 
 	return scanCommand
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -222,11 +222,11 @@ func scanCommand() *cobra.Command {
 	}
 
 	flags := scanCommand.Flags()
-	flags.StringP("id", "", id.ID(), "an ID for associating responses to requests")
+	flags.String("id", id.ID(), "an ID for associating responses to requests")
 	flags.StringP("kind", "k", "GitRepo", "the kind of resource to scan")
 	flags.StringP("options", "o", "{}", "additional request options formatted as JSON")
 	flags.Int("leak-exit-code", 0, "the exit code when leaks are found (default 0)")
-	flags.StringP("gitleaks-config", "", "", "the path to a custom gitleaks config")
+	flags.String("gitleaks-config", "", "the path to a custom gitleaks config")
 
 	return scanCommand
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -94,6 +94,9 @@ func runScan(cmd *cobra.Command, args []string) {
 	// precedence over gitleaks config set in the leaktk config file
 	if len(gitleaksConfig) != 0 {
 		cfg.Scanner.Patterns.Gitleaks.ConfigPath = gitleaksConfig
+
+		// Providing a config automatically disables pattern autofetch
+		cfg.Scanner.Patterns.Autofetch = false
 	}
 
 	request, err := scanCommandToRequest(cmd, args)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -94,9 +94,11 @@ func runScan(cmd *cobra.Command, args []string) {
 	// precedence over gitleaks config set in the leaktk config file
 	if len(gitleaksConfig) != 0 {
 		cfg.Scanner.Patterns.Gitleaks.ConfigPath = gitleaksConfig
+		logger.Debug("using provided gitleaks config: path=%s", gitleaksConfig)
 
 		// Providing a config automatically disables pattern autofetch
 		cfg.Scanner.Patterns.Autofetch = false
+		logger.Debug("disabling pattern autofetch with custom gitleaks config")
 	}
 
 	request, err := scanCommandToRequest(cmd, args)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -99,6 +99,11 @@ func runScan(cmd *cobra.Command, args []string) {
 		// Providing a config automatically disables pattern autofetch
 		cfg.Scanner.Patterns.Autofetch = false
 		logger.Debug("disabling pattern autofetch with custom gitleaks config")
+
+		// and disables pattern expiredafter checks
+		cfg.Scanner.Patterns.ExpiredAfter = 0
+		cfg.Scanner.Patterns.RefreshAfter = 0
+		logger.Debug("disabling pattern expiredafter/refreshafter with custom gitleaks config")
 	}
 
 	request, err := scanCommandToRequest(cmd, args)

--- a/pkg/scanner/patterns.go
+++ b/pkg/scanner/patterns.go
@@ -87,6 +87,12 @@ func (p *Patterns) fetchGitleaksConfig(ctx context.Context) (string, error) {
 // gitleaksConfigModTimeExceeds returns true if the file is older than
 // `modTimeLimit` seconds
 func (p *Patterns) gitleaksConfigModTimeExceeds(modTimeLimit int) bool {
+	// When modTimeLimit is 0, expiration checking is effectively disabled
+	// and gitleaksConfigModTimeExceeds returns false in this case.
+	if modTimeLimit == 0 {
+		return false
+	}
+
 	if fileInfo, err := os.Stat(p.config.Gitleaks.ConfigPath); err == nil {
 		return int(time.Since(fileInfo.ModTime()).Seconds()) > modTimeLimit
 	}


### PR DESCRIPTION
Add `--gitleaks-config` flag for overriding the Gitleaks config `leaktk scan --gitleaks-config <path-to-config>`.

```
LEAKTK_LOGGER_LEVEL=DEBUG ./leaktk scan --gitleaks-config /tmp/wahoo --kind Files /tmp/hehe
[DEBUG] using provided gitleaks config: path=/tmp/wahoo
[DEBUG] disabling pattern autofetch with custom gitleaks config
[DEBUG] disabling pattern expiredafter/refreshafter with custom gitleaks config
[INFO] queueing scan: id="Mc6lCK73nck"
[INFO] starting scan: id="Mc6lCK73nck"
[DEBUG] no additional config
[DEBUG] gitleaks: scanning path
[INFO] queueing response: id="Mc6lCK73nck"
...
```