### PR TITLE
Log fatal error when error on response for single scan

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -82,17 +82,17 @@ func logoutCommand() *cobra.Command {
 func runScan(cmd *cobra.Command, args []string) {
 	leakExitCode, err := cmd.Flags().GetInt("leak-exit-code")
 	if err != nil {
-		logger.Fatal("invalid leak-exit-code: error=%q", err.Error())
+		logger.Fatal("invalid leak-exit-code: %v", err)
 	}
 
 	request, err := scanCommandToRequest(cmd, args)
 	if err != nil {
-		logger.Fatal("could not generate scan request: error=%q", err.Error())
+		logger.Fatal("could not generate scan request: %v", err)
 	}
 
 	formatter, err := NewFormatter(cfg.Formatter)
 	if err != nil {
-		logger.Fatal("%v", err.Error())
+		logger.Fatal("%v", err)
 	}
 
 	var wg sync.WaitGroup
@@ -105,6 +105,9 @@ func runScan(cmd *cobra.Command, args []string) {
 			leaksFound = true
 		}
 		fmt.Println(formatter.Format(response))
+		if response.Error != nil {
+			logger.Fatal("response contains error: %w", response.Error)
+		}
 		wg.Done()
 	})
 
@@ -322,7 +325,7 @@ func configure(cmd *cobra.Command, args []string) error {
 	// Check if the OutputFormat is valid
 	_, err = getOutputFormat(cfg.Formatter.Format)
 	if err != nil {
-		logger.Fatal("%v", err.Error())
+		logger.Fatal("%v", err)
 	}
 
 	return err
@@ -357,6 +360,6 @@ func Execute() {
 		if strings.Contains(err.Error(), "unknown flag") {
 			os.Exit(config.ExitCodeBlockingError)
 		}
-		logger.Fatal("%v", err.Error())
+		logger.Fatal("%v", err)
 	}
 }

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -97,6 +97,11 @@ type Error struct {
 	Data    any    `json:"data,omitempty" toml:"data,omitempty" yaml:"data,omitempty"`
 }
 
+// Error implements go's error interface for Response.Error
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s code=%d", e.Message, e.Code)
+}
+
 // Response from the scanner with the scan result
 type Response struct {
 	ID        string    `json:"id"              toml:"id"              yaml:"id"`

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -249,14 +249,13 @@ func (s *Scanner) listen() {
 				})
 				return
 			default:
-				logger.Error("scan error: %v id=%q", err, request.ID)
 				scanErr = &proto.Error{
 					Code:    scanErrorCode,
 					Message: err.Error(),
 					Data:    request,
 				}
+				logger.Error("scan error: %v id=%q", scanErr, request.ID)
 			}
-
 		}
 
 		results := make([]*proto.Result, len(findings))
@@ -280,7 +279,7 @@ func (s *Scanner) listen() {
 
 func (s *Scanner) respondWithError(request *proto.Request, err *proto.Error) {
 	logger.Info("queueing response: id=%q", request.ID)
-	logger.Error("scan error: %s id=%q", err.Message, request.ID)
+	logger.Error("scan error: %v id=%q", err, request.ID)
 	s.responseQueue.Send(&queue.Message[*proto.Response]{
 		Priority: request.Opts.Priority,
 		Value: &proto.Response{


### PR DESCRIPTION
When single scans were failing due to a misconfiguration in some tests, the exit code was 0 when it shouldn't have been.

This also implements the `error` interface for `proto.Error` 