### PR TITLE
Healthcheck - MVP for Issue #296

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ leaktk scan --kind JSONData '@/path/to/some-file.json'
 # Listen for requests
 leaktk listen < ./examples/requests.jsonl
 
+# Check project defaults that help prevent credential leaks
+leaktk healthcheck
+leaktk healthcheck --fix /path/to/project
+
 # See more options
 leaktk help
 ```
@@ -31,6 +35,7 @@ request even if there were errors. More info on the formats are in the
 - [Request/Response Formats for Listen](docs/listen.md)
 - [Git Hooks](docs/hooks.md)
 - [Redaction](docs/redact.md)
+- [Health Checks](docs/healthcheck.md)
 - (Coming Soon) Analyzing Results
 - (Coming Soon) Monitoring Sources
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/leaktk/leaktk/pkg/config"
 	"github.com/leaktk/leaktk/pkg/fs"
+	"github.com/leaktk/leaktk/pkg/healthcheck"
 	"github.com/leaktk/leaktk/pkg/hooks"
 	"github.com/leaktk/leaktk/pkg/id"
 	"github.com/leaktk/leaktk/pkg/logger"
@@ -504,6 +505,49 @@ func redactCommand() *cobra.Command {
 	return cmd
 }
 
+func runHealthcheck(cmd *cobra.Command, args []string) {
+	project := "."
+	if len(args) == 1 {
+		project = args[0]
+	}
+
+	exitCode, err := cmd.Flags().GetInt("exit-code")
+	if err != nil {
+		logger.Fatal("invalid exit-code: %v", err)
+	}
+
+	result, err := healthcheck.Run(project, mustGetBool(cmd.Flags(), "fix"))
+	if err != nil {
+		logger.Fatal("couldn't run healthcheck: %v", err)
+	}
+
+	formatter, err := NewFormatter(cfg.Formatter)
+	if err != nil {
+		logger.Fatal("%v", err)
+	}
+	fmt.Println(formatter.FormatHealthcheck(result))
+
+	if result.NeedsAction() && exitCode != 0 {
+		os.Exit(exitCode)
+	}
+}
+
+func healthcheckCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "healthcheck [flags] [project]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Check project settings that help prevent credential leaks",
+		Args:                  cobra.MaximumNArgs(1),
+		Run:                   runHealthcheck,
+	}
+
+	flags := cmd.Flags()
+	flags.Bool("fix", false, "Apply the fixes for the reported issues")
+	flags.Int("exit-code", 0, "Exit with this code when issues still need action (default 0)")
+
+	return cmd
+}
+
 func configure(cmd *cobra.Command, args []string) error {
 	switch cmd.Use {
 	case "listen":
@@ -566,6 +610,7 @@ func rootCommand() *cobra.Command {
 	rootCommand.AddCommand(listenCommand())
 	rootCommand.AddCommand(versionCommand())
 	rootCommand.AddCommand(redactCommand())
+	rootCommand.AddCommand(healthcheckCommand())
 
 	return rootCommand
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/leaktk/leaktk/pkg/config"
 	"github.com/leaktk/leaktk/pkg/fs"
+	"github.com/leaktk/leaktk/pkg/healthcheck"
 	"github.com/leaktk/leaktk/pkg/proto"
 )
 
@@ -54,4 +56,40 @@ func TestScanCommandToRequest(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, request)
 	assert.Equal(t, fmt.Sprintf("resource path does not exist: path=%q", dataPath+".invalid"), err.Error())
+}
+
+func TestHealthcheckCommand(t *testing.T) {
+	cmd := healthcheckCommand()
+
+	assert.Equal(t, "healthcheck [flags] [project]", cmd.Use)
+	assert.Equal(t, "Check project settings that help prevent credential leaks", cmd.Short)
+	assert.NotNil(t, cmd.Flags().Lookup("fix"))
+	assert.NotNil(t, cmd.Flags().Lookup("exit-code"))
+}
+
+func TestFormatHealthcheck(t *testing.T) {
+	result := &healthcheck.Result{
+		Project: "/tmp/project",
+		Findings: []healthcheck.Finding{{
+			Policy:      "gitignore.env",
+			Path:        "/tmp/project/.gitignore",
+			Summary:     ".env is not ignored by .gitignore",
+			Remediation: "add .env to .gitignore",
+		}},
+	}
+
+	t.Run("JSON", func(t *testing.T) {
+		formatter, err := NewFormatter(config.Formatter{Format: "JSON"})
+		require.NoError(t, err)
+
+		assert.JSONEq(t, `{"project":"/tmp/project","findings":[{"policy":"gitignore.env","path":"/tmp/project/.gitignore","summary":".env is not ignored by .gitignore","remediation":"add .env to .gitignore","fixed":false}]}`,
+			formatter.FormatHealthcheck(result))
+	})
+
+	t.Run("Human", func(t *testing.T) {
+		formatter, err := NewFormatter(config.Formatter{Format: "HUMAN"})
+		require.NoError(t, err)
+
+		assert.Contains(t, formatter.FormatHealthcheck(result), "Status: needs action")
+	})
 }

--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -5,12 +5,14 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	"gopkg.in/yaml.v3"
 
 	"github.com/leaktk/leaktk/pkg/config"
+	"github.com/leaktk/leaktk/pkg/healthcheck"
 	"github.com/leaktk/leaktk/pkg/logger"
 	"github.com/leaktk/leaktk/pkg/proto"
 )
@@ -182,4 +184,100 @@ func flattenedResponse(response *proto.Response) ([]string, [][]string) {
 // flattenContact creates a single string with Contact information as "Name <Email>"
 func flattenContact(contact proto.Contact) string {
 	return fmt.Sprintf("%s <%s>", contact.Name, contact.Email)
+}
+
+func (f *Formatter) FormatHealthcheck(result *healthcheck.Result) string {
+	switch f.format {
+	case JSON:
+		return formatHealthcheckJSON(result)
+	case HUMAN:
+		return formatHealthcheckHuman(result)
+	case TOML:
+		return formatHealthcheckToml(result)
+	case YAML:
+		return formatHealthcheckYaml(result)
+	case CSV:
+		return formatHealthcheckCsv(result)
+	default:
+		return formatHealthcheckJSON(result)
+	}
+}
+
+func formatHealthcheckJSON(result *healthcheck.Result) string {
+	out, err := json.Marshal(result)
+	if err != nil {
+		logger.Error("could not marshal health check result: error=%q", err)
+	}
+
+	return string(out)
+}
+
+func formatHealthcheckHuman(result *healthcheck.Result) string {
+	if len(result.Findings) == 0 {
+		return fmt.Sprintf("No healthcheck issues found: project=%s", result.Project)
+	}
+
+	var out []string
+	for _, finding := range result.Findings {
+		status := "needs action"
+		if finding.Fixed {
+			status = "fixed"
+		}
+
+		out = append(out, fmt.Sprintf("Policy: %s\nPath: %s\nIssue: %s\nRemediation: %s\nStatus: %s",
+			finding.Policy,
+			finding.Path,
+			finding.Summary,
+			finding.Remediation,
+			status,
+		))
+	}
+
+	return strings.Join(out, "\n\n")
+}
+
+func formatHealthcheckToml(result *healthcheck.Result) string {
+	var buf bytes.Buffer
+
+	if err := toml.NewEncoder(&buf).Encode(result); err != nil {
+		logger.Error("could not marshal health check result: error=%q", err)
+	}
+
+	return buf.String()
+}
+
+func formatHealthcheckYaml(result *healthcheck.Result) string {
+	out, err := yaml.Marshal(result)
+	if err != nil {
+		logger.Error("could not marshal health check result: error=%q", err)
+	}
+
+	return string(out)
+}
+
+func formatHealthcheckCsv(result *healthcheck.Result) string {
+	var buf bytes.Buffer
+	writer := csv.NewWriter(&buf)
+	if err := writer.Write([]string{"PROJECT", "POLICY", "PATH", "SUMMARY", "REMEDIATION", "FIXED"}); err != nil {
+		logger.Error("could not write health check response: error=%q", err)
+	}
+
+	for _, finding := range result.Findings {
+		if err := writer.Write([]string{
+			result.Project,
+			finding.Policy,
+			finding.Path,
+			finding.Summary,
+			finding.Remediation,
+			strconv.FormatBool(finding.Fixed),
+		}); err != nil {
+			logger.Error("could not write health check response: error=%q", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		logger.Error("could not write health check response: error=%q", err)
+	}
+
+	return buf.String()
 }

--- a/docs/healthcheck.md
+++ b/docs/healthcheck.md
@@ -1,0 +1,25 @@
+# Healthcheck
+
+`healthcheck` checks project settings that help prevent credentials from being
+committed. It uses the current directory when no project is provided.
+
+```sh
+# Report issues
+leaktk healthcheck /path/to/project
+
+# Apply safe fixes
+leaktk healthcheck --fix /path/to/project
+
+# Fail when an issue is found (for CI)
+leaktk healthcheck --exit-code 1 /path/to/project
+```
+
+`--fix` only makes changes for findings it can fix safely. Running it more than
+once will not add the same setting again.
+
+Currently, `healthcheck` checks that `.env` is ignored by the project-root
+`.gitignore`. The fix adds `.env` to `.gitignore`, creating that file when
+needed.
+
+The command uses the same `--format` options as `scan`. Each finding includes
+the policy name, affected path, recommended fix, and whether it was fixed.

--- a/pkg/healthcheck/gitignore.go
+++ b/pkg/healthcheck/gitignore.go
@@ -1,0 +1,101 @@
+package healthcheck
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func checkGitIgnoreEnv(project string, fix bool) (*Finding, error) {
+	path := filepath.Join(project, ".gitignore")
+	ignored, err := ignoresEnv(path)
+	if err != nil {
+		return nil, err
+	}
+	if ignored {
+		return nil, nil
+	}
+
+	finding := &Finding{
+		Policy:      gitIgnoreEnvPolicy,
+		Path:        path,
+		Summary:     ".env is not ignored by .gitignore",
+		Remediation: "add .env to .gitignore",
+	}
+	if !fix {
+		return finding, nil
+	}
+
+	if err := addEnvIgnore(path); err != nil {
+		return nil, err
+	}
+	finding.Fixed = true
+
+	return finding, nil
+}
+
+func ignoresEnv(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("could not read .gitignore: %w path=%q", err, path)
+	}
+
+	ignored := false
+	for _, line := range strings.Split(string(data), "\n") {
+		pattern, negated := gitIgnorePattern(line)
+		if (!(pattern == ".env" || pattern == "/.env" || pattern == "**/.env" || pattern == "*.env")) {
+			continue
+		}
+
+		ignored = !negated
+	}
+
+	return ignored, nil
+}
+
+func gitIgnorePattern(line string) (string, bool) {
+	pattern := strings.TrimSuffix(line, "\r")
+	if len(pattern) == 0 || strings.HasPrefix(pattern, "#") {
+		return "", false
+	}
+
+	negated := strings.HasPrefix(pattern, "!")
+	if negated {
+		pattern = strings.TrimPrefix(pattern, "!")
+	}
+
+	return pattern, negated
+}
+
+func addEnvIgnore(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("could not read .gitignore: %w path=%q", err, path)
+	}
+
+	lineEnding := "\n"
+	if bytes.Contains(data, []byte("\r\n")) {
+		lineEnding = "\r\n"
+	}
+	if len(data) > 0 && !bytes.HasSuffix(data, []byte("\n")) {
+		data = append(data, lineEnding...)
+	}
+	data = append(data, ".env"...)
+	data = append(data, lineEnding...)
+
+	mode := os.FileMode(0600)
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		return fmt.Errorf("could not update .gitignore: %w path=%q", err, path)
+	}
+
+	return nil
+}

--- a/pkg/healthcheck/gitignore.go
+++ b/pkg/healthcheck/gitignore.go
@@ -94,7 +94,7 @@ func addEnvIgnore(path string) error {
 		mode = info.Mode().Perm()
 	}
 	if err := os.WriteFile(path, data, mode); err != nil {
-		return fmt.Errorf("could not update .gitignore: %w path=%q", err, path)
+		return fmt.Errorf(".gitignore couldn't be updated: %w path=%q", err, path)
 	}
 
 	return nil

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1,0 +1,57 @@
+package healthcheck
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const gitIgnoreEnvPolicy = "gitignore.env"
+
+
+type Finding struct {
+	Policy      string `json:"policy"`
+	Path        string `json:"path"`
+	Summary     string `json:"summary"`
+	Remediation string `json:"remediation"`
+	Fixed       bool   `json:"fixed"`
+}
+
+type Result struct {
+	Project  string    `json:"project"`
+	Findings []Finding `json:"findings"`
+}
+
+func (r Result) NeedsAction() bool {
+	for _, finding := range r.Findings {
+		if !finding.Fixed {
+			return true
+		}
+	}
+
+	return false
+}
+
+func Run(path string, fix bool) (*Result, error) {
+	project, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve project path: %w", err)
+	}
+
+	info, err := os.Stat(project)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't access project: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("project path is not a directory: path=%q", project)
+	}
+
+	result := &Result{Project: project}
+	if finding, err := checkGitIgnoreEnv(project, fix); err != nil {
+		return nil, err
+	} else if finding != nil {
+		result.Findings = append(result.Findings, *finding)
+	}
+
+	return result, nil
+}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1,0 +1,104 @@
+package healthcheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("ReportsMissingEnvIgnore", func(t *testing.T) {
+		project := t.TempDir()
+
+		result, err := Run(project, false)
+
+		require.NoError(t, err)
+		assert.Equal(t, project, result.Project)
+		require.Len(t, result.Findings, 1)
+		assert.Equal(t, gitIgnoreEnvPolicy, result.Findings[0].Policy)
+		assert.Equal(t, filepath.Join(project, ".gitignore"), result.Findings[0].Path)
+		assert.False(t, result.Findings[0].Fixed)
+		assert.True(t, result.NeedsAction())
+		assert.NoFileExists(t, filepath.Join(project, ".gitignore"))
+	})
+
+	t.Run("RecognizesCommonEnvIgnorePatterns", func(t *testing.T) {
+		for _, pattern := range []string{".env", "/.env", "**/.env", "*.env"} {
+			t.Run(pattern, func(t *testing.T) {
+				project := t.TempDir()
+				err := os.WriteFile(filepath.Join(project, ".gitignore"), []byte(pattern+"\n"), 0600)
+				require.NoError(t, err)
+
+				result, err := Run(project, false)
+
+				require.NoError(t, err)
+				assert.Empty(t, result.Findings)
+			})
+		}
+	})
+
+	t.Run("LastMatchingPatternWins", func(t *testing.T) {
+		project := t.TempDir()
+		err := os.WriteFile(filepath.Join(project, ".gitignore"), []byte(".env\n!.env\n"), 0600)
+		require.NoError(t, err)
+
+		result, err := Run(project, false)
+
+		require.NoError(t, err)
+		assert.Len(t, result.Findings, 1)
+	})
+
+	t.Run("FixCreatesGitIgnore", func(t *testing.T) {
+		project := t.TempDir()
+
+		result, err := Run(project, true)
+
+		require.NoError(t, err)
+		require.Len(t, result.Findings, 1)
+		assert.True(t, result.Findings[0].Fixed)
+		assert.False(t, result.NeedsAction())
+		assert.FileExists(t, filepath.Join(project, ".gitignore"))
+		assertFileContent(t, filepath.Join(project, ".gitignore"), ".env\n")
+
+		result, err = Run(project, true)
+		require.NoError(t, err)
+		assert.Empty(t, result.Findings)
+	})
+
+	t.Run("FixAppendsSeparateLineAndPreservesLineEnding", func(t *testing.T) {
+		project := t.TempDir()
+		path := filepath.Join(project, ".gitignore")
+		err := os.WriteFile(path, []byte("node_modules\r\ncoverage"), 0644)
+		require.NoError(t, err)
+
+		_, err = Run(project, true)
+
+		require.NoError(t, err)
+		assertFileContent(t, path, "node_modules\r\ncoverage\r\n.env\r\n")
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0644), info.Mode().Perm())
+	})
+
+	t.Run("RejectsFilePath", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "project")
+		err := os.WriteFile(path, []byte{}, 0600)
+		require.NoError(t, err)
+
+		result, err := Run(path, false)
+
+		assert.Nil(t, result)
+		require.EqualError(t, err, "project path is not a directory: path="+`"`+path+`"`)
+	})
+}
+
+func assertFileContent(t *testing.T, path string, expected string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(data))
+}


### PR DESCRIPTION
A basic start for issue #296 

`--exit-code` flag for CI runners
`leaktk healthcheck` checks if `.env` is in `.gitignore`
`--fix` flag adds `.env` to `.gitignore`

Not a comprehensive healthcheck, but good to start and build ideas off of.